### PR TITLE
[IMP] add basic module support for CentOS/RHEL

### DIFF
--- a/tasks/install-centos.yml
+++ b/tasks/install-centos.yml
@@ -3,6 +3,7 @@
   when: restart_web_server|bool and www_server == "apache"
   tags:
     - php
+
 - name: Ensure PHP packages are installed.
   yum:
     name: "{{ item }}"
@@ -11,6 +12,7 @@
   notify: restart-php-webserver
   tags:
     - php
+
 - name: Install PHP extensions (modules)
   yum:
     name: php-{{ item }}

--- a/tasks/install-centos.yml
+++ b/tasks/install-centos.yml
@@ -3,12 +3,19 @@
   when: restart_web_server|bool and www_server == "apache"
   tags:
     - php
-
 - name: Ensure PHP packages are installed.
   yum:
     name: "{{ item }}"
     state: installed
   with_items: php_packages
+  notify: restart-php-webserver
+  tags:
+    - php
+- name: Install PHP extensions (modules)
+  yum:
+    name: php-{{ item }}
+    state: installed
+  with_items: php_modules
   notify: restart-php-webserver
   tags:
     - php


### PR DESCRIPTION
This adds support for using the php_modules variable for adding modules when using CentOS or RedHat.   I assumed that the module name for installation would be prepended by "php-"

I'm not sure if you're accepting pull requests or need more information, but please let me know!
